### PR TITLE
Swap deprecated go-ipfs-dep for go-ipfs module

### DIFF
--- a/config/factory.js
+++ b/config/factory.js
@@ -21,7 +21,7 @@ module.exports = {
     go: {
       test: false,
       ipfsHttpModule: require('ipfs-http-client'),
-      ipfsBin: require('go-ipfs-dep').path()
+      ipfsBin: require('go-ipfs').path()
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-test-utils",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4746,9 +4746,9 @@
         "define-properties": "^1.1.3"
       }
     },
-    "go-ipfs-dep": {
+    "go-ipfs": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.6.0.tgz",
       "integrity": "sha512-pehz8LM8RBRW0+u6L6J4XPb1Fs5mj9wJ89F4B3gyBG/z1zMeTYO6wqcgphfHBtK/uHAu4Ce0nCFR8TGClP8bBg==",
       "requires": {
         "go-platform": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "fruitdown": "^1.0.2",
-    "go-ipfs-dep": "~0.6.0",
+    "go-ipfs": "~0.6.0",
     "ipfs": "^0.48.0",
     "ipfs-http-client": "~45.0.0",
     "ipfs-repo": "^4.0.0",

--- a/test-apis.js
+++ b/test-apis.js
@@ -20,7 +20,7 @@ const goIpfs = {
     disposable: true,
     args: ['--enable-pubsub-experiment'],
     ipfsHttpModule: require('ipfs-http-client'),
-    ipfsBin: require('go-ipfs-dep').path()
+    ipfsBin: require('go-ipfs').path()
   }
 }
 


### PR DESCRIPTION
go-ipfs-dep has been deprecated, go-ipfs is a drop-in replacement: https://github.com/ipfs/npm-go-ipfs-dep/pull/46