### PR TITLE
Updating js-ipfs to 0.49 and other npm updates

### DIFF
--- a/mem-store.js
+++ b/mem-store.js
@@ -25,7 +25,7 @@ class MemStore {
   async put (value) {
     const buffer = Buffer.from(JSON.stringify(value))
     const multihash = await multihashing(buffer, 'sha2-256')
-    const cid = new CID(1, 'dag-cbor', multihash)
+    const cid = new CID(1, 'dag-cbor', Buffer.from(multihash))
     const key = cid.toBaseEncodedString(defaultBase)
 
     this._store.set(key, value)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-test-utils",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,16 +18,16 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.4.tgz",
+      "integrity": "sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.0",
+        "@babel/generator": "^7.11.4",
         "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.1",
+        "@babel/parser": "^7.11.4",
         "@babel/template": "^7.10.4",
         "@babel/traverse": "^7.11.0",
         "@babel/types": "^7.11.0",
@@ -50,9 +50,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-      "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+      "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
       "requires": {
         "@babel/types": "^7.11.0",
         "jsesc": "^2.5.1",
@@ -176,9 +176,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
-      "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA=="
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+      "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA=="
     },
     "@babel/template": {
       "version": "7.10.4",
@@ -1811,27 +1811,10 @@
         "responselike": "^1.0.2"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
         }
       }
     },
@@ -1893,6 +1876,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "optional": true
+    },
+    "cbor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.1.0.tgz",
+      "integrity": "sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "nofilter": "^1.0.4"
+      }
     },
     "chai": {
       "version": "4.2.0",
@@ -2305,21 +2297,6 @@
       "requires": {
         "cids": "^0.8.0",
         "ipld-dag-cbor": "^0.16.0"
-      },
-      "dependencies": {
-        "ipld-dag-cbor": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
-          "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
-          "requires": {
-            "borc": "^2.1.2",
-            "buffer": "^5.6.0",
-            "cids": "~0.8.3",
-            "is-circular": "^1.0.2",
-            "multicodec": "^1.0.3",
-            "multihashing-async": "^1.0.0"
-          }
-        }
       }
     },
     "dashdash": {
@@ -3747,25 +3724,6 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2",
         "strip-final-newline": "^2.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
       }
     },
     "explain-error": {
@@ -4711,9 +4669,9 @@
       "dev": true
     },
     "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "requires": {
         "pump": "^3.0.0"
       },
@@ -4781,16 +4739,16 @@
         "define-properties": "^1.1.3"
       }
     },
-    "go-ipfs-dep": {
+    "go-ipfs": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.6.0.tgz",
-      "integrity": "sha512-pehz8LM8RBRW0+u6L6J4XPb1Fs5mj9wJ89F4B3gyBG/z1zMeTYO6wqcgphfHBtK/uHAu4Ce0nCFR8TGClP8bBg==",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.6.0.tgz",
+      "integrity": "sha512-GKt5qae+5C2Oe54Y2eWXGjf7/AD+LPG+AZB9BfKZP2xA7Y5emxFYxIn2lzrf7jY4Pc4HzrK2Mr4Ei5wwWbYURg==",
       "requires": {
         "go-platform": "^1.0.0",
-        "gunzip-maybe": "^1.4.1",
-        "node-fetch": "^2.3.0",
+        "gunzip-maybe": "^1.4.2",
+        "node-fetch": "^2.6.0",
         "pkg-conf": "^3.1.0",
-        "tar-fs": "^2.0.0",
+        "tar-fs": "^2.1.0",
         "unzip-stream": "^0.3.0"
       }
     },
@@ -4817,10 +4775,27 @@
         "url-parse-lax": "^3.0.0"
       },
       "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
         "p-cancelable": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
           "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
         }
       }
     },
@@ -5266,9 +5241,9 @@
       "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
     },
     "ipfs": {
-      "version": "0.48.2",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.48.2.tgz",
-      "integrity": "sha512-lBOI4BgdH8YEwhuuM0dWBu2HHdWDF+gEthalDf0xeYlW+AwtqZI0g80a1QyXgdDKfNcm3TYcHnZJfN1ssx0fEA==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.49.0.tgz",
+      "integrity": "sha512-v1NpOoHDWmsRFaic2oYWAT/m7QnoF9GaPFT07u47g6rnYujp2IW5U8pQKVVAMgdyGsWpWALHuMJ13WBUZMfYYg==",
       "requires": {
         "@hapi/ammo": "^3.1.2",
         "@hapi/boom": "^7.4.3",
@@ -5292,6 +5267,7 @@
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
+        "execa": "^4.0.0",
         "file-type": "^14.1.4",
         "fnv1a": "^1.0.1",
         "get-folder-size": "^2.0.0",
@@ -5301,8 +5277,8 @@
         "interface-datastore": "^1.0.2",
         "ipfs-bitswap": "^2.0.1",
         "ipfs-block-service": "^0.17.1",
-        "ipfs-core-utils": "^0.3.0",
-        "ipfs-http-client": "^45.0.0",
+        "ipfs-core-utils": "^0.3.1",
+        "ipfs-http-client": "^46.0.0",
         "ipfs-http-response": "^0.5.0",
         "ipfs-repo": "^4.0.0",
         "ipfs-unixfs": "^1.0.3",
@@ -5311,9 +5287,9 @@
         "ipfs-utils": "^2.2.2",
         "ipld": "^0.26.2",
         "ipld-bitcoin": "^0.3.0",
-        "ipld-block": "^0.9.1",
-        "ipld-dag-cbor": "^0.15.2",
-        "ipld-dag-pb": "^0.18.5",
+        "ipld-block": "^0.9.2",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
         "ipld-ethereum": "^4.0.0",
         "ipld-git": "^0.5.0",
         "ipld-raw": "^5.0.0",
@@ -5336,9 +5312,9 @@
         "iterable-ndjson": "^1.1.0",
         "jsondiffpatch": "^0.4.1",
         "just-safe-set": "^2.1.0",
-        "libp2p": "^0.28.5",
+        "libp2p": "^0.28.10",
         "libp2p-bootstrap": "^0.11.0",
-        "libp2p-crypto": "^0.17.8",
+        "libp2p-crypto": "^0.17.9",
         "libp2p-delegated-content-routing": "^0.5.0",
         "libp2p-delegated-peer-routing": "^0.5.0",
         "libp2p-floodsub": "^0.21.0",
@@ -5368,7 +5344,7 @@
         "progress": "^2.0.1",
         "prom-client": "^12.0.0",
         "prometheus-gc-stats": "^0.6.0",
-        "protons": "^1.2.0",
+        "protons": "^1.2.1",
         "semver": "^7.3.2",
         "stream-to-it": "^0.2.1",
         "streaming-iterables": "^5.0.0",
@@ -5379,6 +5355,59 @@
         "varint": "^5.0.0",
         "yargs": "^15.1.0",
         "yargs-promise": "^1.1.0"
+      },
+      "dependencies": {
+        "ipfs-repo": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-4.0.0.tgz",
+          "integrity": "sha512-rhmRjO3ekS4/RzgNB1EQOudKCCYK23Lb2/E6eD3So5r0bX1PvDdybbzfpDj05HBoNmvDy9pYDJzdtdH7a4gP3w==",
+          "requires": {
+            "bignumber.js": "^9.0.0",
+            "buffer": "^5.6.0",
+            "bytes": "^3.1.0",
+            "cids": "^0.8.0",
+            "datastore-core": "^1.1.0",
+            "datastore-fs": "^1.1.0",
+            "datastore-level": "^1.1.0",
+            "debug": "^4.1.0",
+            "err-code": "^2.0.0",
+            "interface-datastore": "^1.0.2",
+            "ipfs-repo-migrations": "^1.0.0",
+            "ipfs-utils": "^2.2.0",
+            "ipld-block": "^0.9.1",
+            "it-map": "^1.0.2",
+            "it-pushable": "^1.4.0",
+            "just-safe-get": "^2.0.0",
+            "just-safe-set": "^2.1.0",
+            "multibase": "^1.0.1",
+            "p-queue": "^6.0.0",
+            "proper-lockfile": "^4.0.0",
+            "sort-keys": "^4.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipfs-bitswap": {
@@ -5402,6 +5431,31 @@
         "protons": "^1.0.1",
         "streaming-iterables": "^5.0.2",
         "varint-decoder": "^0.4.0"
+      },
+      "dependencies": {
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipfs-block-service": {
@@ -5437,9 +5491,9 @@
       }
     },
     "ipfs-http-client": {
-      "version": "45.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-45.0.0.tgz",
-      "integrity": "sha512-ccD2LCVYnSL0yANFQ2GboKV5RTk6Qi45T62Cz9S86qgKa8vw4AK8O30YncHOzbkbuCX1yRBkncYFktcDd/W/nw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-46.0.0.tgz",
+      "integrity": "sha512-7aSluSl4BzZXHhS60OgUxr3HYjIfszWxzYNevF9008c0/nfqHDRKm9Q4J+zd+S1tJS0JNTRuCOfGVE35g+jtTw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
@@ -5448,11 +5502,11 @@
         "cids": "^0.8.3",
         "debug": "^4.1.0",
         "form-data": "^3.0.0",
-        "ipfs-core-utils": "^0.3.0",
+        "ipfs-core-utils": "^0.3.1",
         "ipfs-utils": "^2.2.2",
-        "ipld-block": "^0.9.1",
-        "ipld-dag-cbor": "^0.15.2",
-        "ipld-dag-pb": "^0.18.5",
+        "ipld-block": "^0.9.2",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
         "ipld-raw": "^5.0.0",
         "iso-url": "^0.4.7",
         "it-last": "^1.0.1",
@@ -5468,7 +5522,7 @@
         "nanoid": "^3.0.2",
         "node-fetch": "^2.6.0",
         "parse-duration": "^0.4.4",
-        "stream-to-it": "^0.2.0"
+        "stream-to-it": "^0.2.1"
       },
       "dependencies": {
         "multihashes": {
@@ -5509,31 +5563,193 @@
       }
     },
     "ipfs-repo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-4.0.0.tgz",
-      "integrity": "sha512-rhmRjO3ekS4/RzgNB1EQOudKCCYK23Lb2/E6eD3So5r0bX1PvDdybbzfpDj05HBoNmvDy9pYDJzdtdH7a4gP3w==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-6.0.3.tgz",
+      "integrity": "sha512-98dAkXAbX0JDGg2ML+h3usEZbQzghF/sCfAM/1Knh/VLdC7xcy34MqZQl+LyRTQEz872iUgk/TqqjkX2Sr2j2A==",
       "requires": {
         "bignumber.js": "^9.0.0",
-        "buffer": "^5.6.0",
         "bytes": "^3.1.0",
-        "cids": "^0.8.0",
-        "datastore-core": "^1.1.0",
-        "datastore-fs": "^1.1.0",
-        "datastore-level": "^1.1.0",
+        "cids": "^1.0.0",
+        "datastore-core": "^2.0.0",
+        "datastore-fs": "^2.0.0",
+        "datastore-level": "^2.0.0",
         "debug": "^4.1.0",
         "err-code": "^2.0.0",
-        "interface-datastore": "^1.0.2",
-        "ipfs-repo-migrations": "^1.0.0",
-        "ipfs-utils": "^2.2.0",
-        "ipld-block": "^0.9.1",
+        "interface-datastore": "^2.0.0",
+        "ipfs-repo-migrations": "^5.0.3",
+        "ipfs-utils": "^2.3.1",
+        "ipld-block": "^0.10.0",
         "it-map": "^1.0.2",
         "it-pushable": "^1.4.0",
         "just-safe-get": "^2.0.0",
         "just-safe-set": "^2.1.0",
-        "multibase": "^1.0.1",
+        "multibase": "^3.0.0",
         "p-queue": "^6.0.0",
         "proper-lockfile": "^4.0.0",
-        "sort-keys": "^4.0.0"
+        "sort-keys": "^4.0.0",
+        "uint8arrays": "^1.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+          "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashes": "^3.0.1",
+            "uint8arrays": "^1.0.0"
+          }
+        },
+        "datastore-core": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.0.tgz",
+          "integrity": "sha512-E6SS3GEZNMCRZScWO98qQ14MIb7+3MLsJtcgla/ULCjfnhThsUE21HN+wT0+QLoYrKR54puWy/3XKp5N+5+zyA==",
+          "requires": {
+            "debug": "^4.1.1",
+            "interface-datastore": "^2.0.0",
+            "ipfs-utils": "^2.3.1"
+          }
+        },
+        "datastore-fs": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
+          "integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
+          "requires": {
+            "datastore-core": "^2.0.0",
+            "fast-write-atomic": "^0.2.0",
+            "interface-datastore": "^2.0.0",
+            "it-glob": "0.0.8",
+            "mkdirp": "^1.0.4"
+          }
+        },
+        "datastore-level": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-2.0.0.tgz",
+          "integrity": "sha512-52qSxZG75QRqO502cSvnYnXj/5sO29Dvtd9uuiRLSzUaSPher8pS0hl5xzlx7zglpzAjQpjaq9oy2UFO6vMn6g==",
+          "requires": {
+            "datastore-core": "^2.0.0",
+            "interface-datastore": "^2.0.0",
+            "level": "^5.0.1"
+          }
+        },
+        "interface-datastore": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
+          "integrity": "sha512-wOImix5uVEZWo+8zPSRMJ9nHbszZi3PhZ14KHLN7oRQjaYQtjtOpYj6n5EXTjDAfIQI8KN9vntHXxyAw1lcRIA==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "err-code": "^2.0.1",
+            "ipfs-utils": "^2.3.1",
+            "iso-random-stream": "^1.1.1",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "nanoid": "^3.0.2"
+          }
+        },
+        "ipfs-repo-migrations": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-5.0.5.tgz",
+          "integrity": "sha512-dbg9LY+f1MhKLCUTQ28z+TmS7+fC6dgZPJhsWpNXSSwicEgMjUssGMoaft9AjoOuOTISeF3WWVVKRqFpOvCxQg==",
+          "requires": {
+            "cbor": "^5.0.2",
+            "cids": "^1.0.0",
+            "datastore-core": "^2.0.0",
+            "debug": "^4.1.0",
+            "fnv1a": "^1.0.1",
+            "interface-datastore": "^2.0.0",
+            "ipld-dag-pb": "^0.20.0",
+            "it-length": "0.0.2",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.0",
+            "proper-lockfile": "^4.1.1",
+            "protons": "^2.0.0",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "ipld-block": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.0.tgz",
+          "integrity": "sha512-2Bh2byWQdvBPvb/jXcOkMu0ejKgb13LrBOy2cC9z/qBD2W7Og6t6XA1Ui+xnxZeEHeDDcFnPLayL6n0bmT+1FA==",
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.20.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
+          "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.0",
+            "protons": "^2.0.0",
+            "reset": "^0.1.0",
+            "run": "^1.4.0",
+            "stable": "^0.1.8",
+            "uint8arrays": "^1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "multibase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+          "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "multicodec": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+          "integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
+          "requires": {
+            "uint8arrays": "1.0.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+              "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            }
+          }
+        },
+        "multihashes": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+          "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "protons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
+          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+          "requires": {
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "ipfs-repo-migrations": {
@@ -5620,6 +5836,20 @@
         "rabin-wasm": "^0.1.1"
       },
       "dependencies": {
+        "ipld-dag-pb": {
+          "version": "0.18.5",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
+          "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.1",
+            "multihashing-async": "~0.8.1",
+            "protons": "^1.0.2",
+            "stable": "^0.1.8"
+          }
+        },
         "multihashes": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
@@ -5666,9 +5896,9 @@
       }
     },
     "ipfsd-ctl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-5.0.0.tgz",
-      "integrity": "sha512-XQVoyOevEUJ6kcbrt5B+VJlM1rC52JmXKicqeQXZ6cYk/i5HjrfoCPBlueEqUYa7QqFxKoqI2MupSb5o1xh3RA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-6.0.0.tgz",
+      "integrity": "sha512-/tTzrKgMXqq/pcLnb7RNv69yCJ09YK7cjvxPbleB2Zb2gcKhn/rDMtDwRWW+/QkDjb6pYpTp6uHPeFXAjqFrDA==",
       "requires": {
         "@hapi/boom": "^8.0.1",
         "@hapi/hapi": "^18.4.1",
@@ -5678,7 +5908,7 @@
         "fs-extra": "^9.0.0",
         "ipfs-utils": "^2.2.0",
         "merge-options": "^2.0.0",
-        "multiaddr": "^7.2.1",
+        "multiaddr": "^8.0.0",
         "nanoid": "^3.1.3",
         "temp-write": "^4.0.0"
       },
@@ -5749,6 +5979,70 @@
               "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
             }
           }
+        },
+        "cids": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+          "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashes": "^3.0.1",
+            "uint8arrays": "^1.0.0"
+          }
+        },
+        "multiaddr": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
+          "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.1.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multibase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+          "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "multicodec": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+          "integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
+          "requires": {
+            "uint8arrays": "1.0.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+              "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            }
+          }
+        },
+        "multihashes": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+          "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          }
         }
       }
     },
@@ -5766,35 +6060,6 @@
         "merge-options": "^2.0.0",
         "multicodec": "^1.0.0",
         "typical": "^6.0.0"
-      },
-      "dependencies": {
-        "ipld-dag-cbor": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
-          "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
-          "requires": {
-            "borc": "^2.1.2",
-            "buffer": "^5.6.0",
-            "cids": "~0.8.3",
-            "is-circular": "^1.0.2",
-            "multicodec": "^1.0.3",
-            "multihashing-async": "^1.0.0"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
-          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "cids": "~0.8.3",
-            "class-is": "^1.1.0",
-            "multicodec": "^1.0.3",
-            "multihashing-async": "^1.0.0",
-            "protons": "^1.2.1",
-            "stable": "^0.1.8"
-          }
-        }
       }
     },
     "ipld-bitcoin": {
@@ -5819,6 +6084,19 @@
             "multibase": "^1.0.1",
             "varint": "^5.0.0"
           }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
         }
       }
     },
@@ -5833,16 +6111,16 @@
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
-      "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
+      "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
       "requires": {
         "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.3",
         "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0"
       },
       "dependencies": {
         "multihashes": {
@@ -5856,9 +6134,9 @@
           }
         },
         "multihashing-async": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
           "requires": {
             "blakejs": "^1.1.0",
             "buffer": "^5.4.3",
@@ -5871,16 +6149,16 @@
       }
     },
     "ipld-dag-pb": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
-      "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+      "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "~0.8.0",
+        "cids": "~0.8.3",
         "class-is": "^1.1.0",
-        "multicodec": "^1.0.1",
-        "multihashing-async": "~0.8.1",
-        "protons": "^1.0.2",
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0",
+        "protons": "^1.2.1",
         "stable": "^0.1.8"
       },
       "dependencies": {
@@ -5895,9 +6173,9 @@
           }
         },
         "multihashing-async": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
           "requires": {
             "blakejs": "^1.1.0",
             "buffer": "^5.4.3",
@@ -5935,6 +6213,19 @@
             "multibase": "^1.0.1",
             "varint": "^5.0.0"
           }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
         }
       }
     },
@@ -5949,6 +6240,31 @@
         "multihashing-async": "^1.0.0",
         "smart-buffer": "^4.1.0",
         "strftime": "^0.10.0"
+      },
+      "dependencies": {
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-raw": {
@@ -6007,6 +6323,19 @@
             "buffer": "^5.6.0",
             "multibase": "^1.0.1",
             "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
@@ -6591,6 +6920,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.2.tgz",
       "integrity": "sha512-zjWiVvkDXKxGA+u2ZNzq321RWnj52RLucsIX0Bve3NUX3X/b1RjtUufvUdjtkFtQLKG1yCf5+hxbdeIYiRT1rQ=="
+    },
+    "it-length": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-0.0.2.tgz",
+      "integrity": "sha512-4HJKhSx/hWg54DLzDSe4HYtjMqDVj2ZR8WBTjJuGqRTH342x2vt6h9KeycUgzNNfygSLJvGzFYtZ7Gw1Kez9Qg=="
     },
     "it-length-prefixed": {
       "version": "3.1.0",
@@ -9169,25 +9503,34 @@
       }
     },
     "multihashing-async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-      "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
+      "integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
       "requires": {
         "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
         "err-code": "^2.0.0",
         "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
+        "multihashes": "^3.0.1",
+        "murmurhash3js-revisited": "^3.0.0",
+        "uint8arrays": "^1.0.0"
       },
       "dependencies": {
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+        "multibase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+          "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
           "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
+            "base-x": "^3.0.8",
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "multihashes": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+          "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.0.0",
             "varint": "^5.0.0"
           }
         }
@@ -9412,6 +9755,11 @@
       "requires": {
         "process-on-spawn": "^1.0.0"
       }
+    },
+    "nofilter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -11016,6 +11364,11 @@
         }
       }
     },
+    "reset": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/reset/-/reset-0.1.0.tgz",
+      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs="
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -11080,6 +11433,14 @@
       "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
       "requires": {
         "bn.js": "^4.11.1"
+      }
+    },
+    "run": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
+      "integrity": "sha1-4X2ekEOrL+F3dsspnhI3848LT/o=",
+      "requires": {
+        "minimatch": "*"
       }
     },
     "run-async": {
@@ -12399,9 +12760,9 @@
       }
     },
     "web-encoding": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.2.tgz",
-      "integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.3.tgz",
+      "integrity": "sha512-Ajn64qJ0Z3oMwOIwBtxajFPA+4guB12n4EfmY1Mtlgb9296WJxwH1q/ykedmQrBNpjcKCM207S5OM2wpJfl4VA=="
     },
     "webcrypto": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-test-utils",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "",
   "main": "index.js",
   "repository": {
@@ -17,22 +17,23 @@
   "standard": {
     "env": "mocha"
   },
+  "note": "DO NOT UPGRADE js-combinatorics",
   "author": "",
   "license": "ISC",
   "dependencies": {
     "fruitdown": "^1.0.2",
-    "go-ipfs": "~0.6.0",
-    "ipfs": "^0.48.0",
-    "ipfs-http-client": "~45.0.0",
-    "ipfs-repo": "^4.0.0",
-    "ipfsd-ctl": "^5.0.0",
-    "js-combinatorics": "^0.6.1",
+    "go-ipfs": "^0.6.0",
+    "ipfs": "^0.49.0",
+    "ipfs-http-client": "~46.0.0",
+    "ipfs-repo": "^6.0.3",
+    "ipfsd-ctl": "^6.0.0",
+    "js-combinatorics": "0.6.1",
     "jsondown": "^1.0.0",
     "localstorage-down": "^0.6.7",
     "memdown": "^5.1.0",
     "mongo-unit": "^2.0.1",
     "mongodown": "^2.0.0",
-    "multihashing-async": "^1.0.0",
+    "multihashing-async": "^2.0.1",
     "orbit-db-storage-adapter": "^0.5.3",
     "redisdown": "^0.1.12",
     "sqldown": "^2.1.0",


### PR DESCRIPTION
This PR updates:
- "ipfs": "^0.49.0",
- "ipfs-http-client": "~46.0.0",
- "ipfs-repo": "^6.0.3",
- "ipfsd-ctl": "^6.0.0",
- "js-combinatorics": "0.6.1",

I did *NOT* update `js-combinatorics` to the latest, 1.4.3, because their latest version uses ES2015 imports which are not LTS in node.js yet.