### PR TITLE
removing default repo location

### DIFF
--- a/config/browser.js
+++ b/config/browser.js
@@ -8,7 +8,6 @@ module.exports = {
     preload: {
       enabled: false
     },
-    repo: './ipfs/ipfs-log/tests/daemon',
     start: true,
     EXPERIMENTAL: {
       pubsub: true
@@ -32,7 +31,6 @@ module.exports = {
     }
   },
   daemon1: {
-    repo: './ipfs/ipfs-log/tests/daemon1',
     start: true,
     relay: { enabled: true, hop: { enabled: true, active: true } },
     EXPERIMENTAL: {
@@ -57,7 +55,6 @@ module.exports = {
     }
   },
   daemon2: {
-    repo: './ipfs/ipfs-log/tests/daemon2',
     start: true,
     relay: { enabled: true, hop: { enabled: true, active: true } },
     EXPERIMENTAL: {

--- a/config/node.js
+++ b/config/node.js
@@ -8,7 +8,6 @@ module.exports = {
     preload: {
       enabled: false
     },
-    repo: './ipfs/ipfs-log/tests/daemon',
     start: true,
     EXPERIMENTAL: {
       pubsub: true
@@ -32,7 +31,6 @@ module.exports = {
     }
   },
   daemon1: {
-    repo: './ipfs/ipfs-log/tests/daemon1',
     start: true,
     EXPERIMENTAL: {
       pubsub: true
@@ -56,7 +54,6 @@ module.exports = {
     }
   },
   daemon2: {
-    repo: './ipfs/ipfs-log/tests/daemon2',
     start: true,
     EXPERIMENTAL: {
       pubsub: true


### PR DESCRIPTION
This PR removes the `config.*.repo` settings from the default configs, as the repo filesystem stuff is now handled by `ipfsd-ctl`'s `test` and `disposable` settings. The downstream effect of this is that we'll need to remove the `ipfsPath` and `rimraf` stuff from the tests in other repos, but that's a good thing :+1: 