### PR TITLE
Disabling mdns in default config

### DIFF
--- a/config/node.js
+++ b/config/node.js
@@ -21,7 +21,7 @@ module.exports = {
       Bootstrap: [],
       Discovery: {
         MDNS: {
-          Enabled: true,
+          Enabled: false,
           Interval: 0
         },
         webRTCStar: {
@@ -44,7 +44,7 @@ module.exports = {
       Bootstrap: [],
       Discovery: {
         MDNS: {
-          Enabled: true,
+          Enabled: false,
           Interval: 0
         },
         webRTCStar: {


### PR DESCRIPTION
CI issue, `go-ipfs` tests are failing.

```strace
socket(AF_INET, SOCK_STREAM|SOCK_CLOEXEC|SOCK_NONBLOCK, IPPROTO_IP) = 36
connect(36, {sa_family=AF_INET, sin_port=htons(33699), sin_addr=inet_addr("127.0.0.1")}, 16) = -1 EINPROGRESS (Operation
 now in progress)
epoll_ctl(13, EPOLL_CTL_ADD, 36, {EPOLLOUT, {u32=36, u64=36}}) = 0
epoll_wait(13, [{EPOLLOUT, {u32=36, u64=36}}], 1024, 0) = 1
getsockopt(36, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
write(36, "POST /api/v0/pubsub/peers?arg=XX"..., 219) = 219
epoll_ctl(13, EPOLL_CTL_ADD, 36, {EPOLLIN, {u32=36, u64=36}}) = -1 EEXIST (File exists)
epoll_ctl(13, EPOLL_CTL_MOD, 36, {EPOLLIN, {u32=36, u64=36}}) = 0
epoll_wait(13, [], 1024, 0)             = 0
epoll_wait(13, [{EPOLLIN, {u32=36, u64=36}}], 1024, 199) = 1
```

Disabling this on a hunch worked in CI so now I'm trying and see if CircleCI doesn't clam up consistently.