### PR TITLE
Support latest go and js ipfs versions

### DIFF
--- a/config/browser.js
+++ b/config/browser.js
@@ -15,7 +15,7 @@ module.exports = {
       Addresses: {
         API: '/ip4/127.0.0.1/tcp/0',
         Swarm: [],
-        Gateway: '/ip4/0.0.0.0/tcp/0'
+        Gateway: '/ip4/127.0.0.1/tcp/0'
       },
       Bootstrap: [],
       Discovery: {
@@ -38,7 +38,7 @@ module.exports = {
       Addresses: {
         API: '/ip4/127.0.0.1/tcp/0',
         Swarm: ['/dns4/wrtc-star1.par.dwebops.pub/tcp/443/wss/p2p-webrtc-star'],
-        Gateway: '/ip4/0.0.0.0/tcp/0'
+        Gateway: '/ip4/127.0.0.1/tcp/0'
       },
       Bootstrap: [],
       Discovery: {
@@ -61,7 +61,7 @@ module.exports = {
       Addresses: {
         API: '/ip4/127.0.0.1/tcp/0',
         Swarm: ['/dns4/wrtc-star1.par.dwebops.pub/tcp/443/wss/p2p-webrtc-star'],
-        Gateway: '/ip4/0.0.0.0/tcp/0'
+        Gateway: '/ip4/127.0.0.1/tcp/0'
       },
       Bootstrap: [],
       Discovery: {

--- a/config/browser.js
+++ b/config/browser.js
@@ -8,7 +8,6 @@ module.exports = {
     preload: {
       enabled: false
     },
-    start: true,
     EXPERIMENTAL: {
       pubsub: true
     },
@@ -31,7 +30,6 @@ module.exports = {
     }
   },
   daemon1: {
-    start: true,
     relay: { enabled: true, hop: { enabled: true, active: true } },
     EXPERIMENTAL: {
       pubsub: true
@@ -55,7 +53,6 @@ module.exports = {
     }
   },
   daemon2: {
-    start: true,
     relay: { enabled: true, hop: { enabled: true, active: true } },
     EXPERIMENTAL: {
       pubsub: true

--- a/config/node.js
+++ b/config/node.js
@@ -14,8 +14,8 @@ module.exports = {
     config: {
       Addresses: {
         API: '/ip4/127.0.0.1/tcp/0',
-        Swarm: ['/ip4/0.0.0.0/tcp/0'],
-        Gateway: '/ip4/0.0.0.0/tcp/0'
+        Swarm: ['/ip4/127.0.0.1/tcp/0'],
+        Gateway: '/ip4/127.0.0.1/tcp/0'
       },
       Bootstrap: [],
       Discovery: {
@@ -36,8 +36,8 @@ module.exports = {
     config: {
       Addresses: {
         API: '/ip4/127.0.0.1/tcp/0',
-        Swarm: ['/ip4/0.0.0.0/tcp/0'],
-        Gateway: '/ip4/0.0.0.0/tcp/0'
+        Swarm: ['/ip4/127.0.0.1/tcp/0'],
+        Gateway: '/ip4/127.0.0.1/tcp/0'
       },
       Bootstrap: [],
       Discovery: {
@@ -58,8 +58,8 @@ module.exports = {
     config: {
       Addresses: {
         API: '/ip4/127.0.0.1/tcp/0',
-        Swarm: ['/ip4/0.0.0.0/tcp/0'],
-        Gateway: '/ip4/0.0.0.0/tcp/0'
+        Swarm: ['/ip4/127.0.0.1/tcp/0'],
+        Gateway: '/ip4/127.0.0.1/tcp/0'
       },
       Bootstrap: [],
       Discovery: {

--- a/config/node.js
+++ b/config/node.js
@@ -8,7 +8,6 @@ module.exports = {
     preload: {
       enabled: false
     },
-    start: true,
     EXPERIMENTAL: {
       pubsub: true
     },
@@ -31,7 +30,6 @@ module.exports = {
     }
   },
   daemon1: {
-    start: true,
     EXPERIMENTAL: {
       pubsub: true
     },
@@ -54,7 +52,6 @@ module.exports = {
     }
   },
   daemon2: {
-    start: true,
     EXPERIMENTAL: {
       pubsub: true
     },

--- a/connect-peers.js
+++ b/connect-peers.js
@@ -2,17 +2,43 @@
 
 const defaultFilter = () => true
 
-const connectIpfsNodes = async (ipfs1, ipfs2, options = {
+const connectIpfsNodes = (ipfs1, ipfs2, options = {
   filter: defaultFilter
-}) => {
-  const id1 = await ipfs1.id()
-  const id2 = await ipfs2.id()
+}) => new Promise((resolve, reject) => {
+  console.log('connect')
+  {(async function setup () {
+    try {
+      const id1 = await ipfs1.id()
+      const id2 = await ipfs2.id()
+      const addresses1 = id1.addresses.filter(options.filter)
+      const addresses2 = id2.addresses.filter(options.filter)
 
-  const addresses1 = id1.addresses.filter(options.filter)
-  const addresses2 = id2.addresses.filter(options.filter)
+      const swarm = async (command) => {
+        // https://github.com/ipfs/go-ipfs/issues/7734
+        await ipfs1.swarm[command](addresses2[0])
+        await ipfs2.swarm[command](addresses1[0])
+      }
 
-  await ipfs1.swarm.connect(addresses2[0])
-  await ipfs2.swarm.connect(addresses1[0])
-}
+      await swarm('connect')
+      // check for suspect peer streams config
+      // streams property only exists on go-ipfs api
+      const streams1 = (await ipfs1.swarm.peers({ verbose: true }))[0].streams
+      const streams2 = (await ipfs2.swarm.peers({ verbose: true }))[0].streams
+      if (streams1 && streams2 && (streams1.length < 4 || streams2.length < 4)) {
+        await swarm('disconnect')
+
+        console.log('reconnect')
+        setTimeout(setup, 1000)
+      } else {
+        console.log('connected')
+        resolve()
+      }
+    } catch (e) {
+      console.error('orbit-db-test-utils/connectPeers has failed')
+      console.error(e)
+      reject(e)
+    }
+  })()}
+})
 
 module.exports = connectIpfsNodes


### PR DESCRIPTION
summary of changes
- reconnects go-ipfs nodes on after checking for suspect peer stream config
- makes tests only use localhost for their swarm addresses
- removes an ipfsConfig option that doesnt play nice with js-ipfs 0.52.0

this pr will
- allow support for js-ipfs 0.52.0
- test ipfs nodes will only use localhost for swarm address
- reduce frequency of go-ipfs test timeouts significantly
