### PR TITLE
Revert pubsub flag

### DIFF
--- a/src/test-apis.js
+++ b/src/test-apis.js
@@ -24,7 +24,7 @@ const goIpfs = {
     type: 'go',
     test: true,
     disposable: true,
-    args: [],
+    args: ['--enable-pubsub-experiment'],
     ipfsHttpModule,
     ipfsBin: ipfsBin.path()
   }


### PR DESCRIPTION
--enable-pubsub-experiment is still needed, so reverting the change back from #51